### PR TITLE
Add OpenRouter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ The backend supports multiple LLM providers through a unified interface. Current
 - **Anthropic** (Claude models)
 - **Groq** (Llama3.2 90 B)
 - **Ollama** (Local models that supports function calling)
+- **OpenAI** (GPT models)
+- **OpenRouter** (access to Bedrock models)
 
 
 

--- a/backend/API_DOCUMENTATION.md
+++ b/backend/API_DOCUMENTATION.md
@@ -14,6 +14,8 @@ Create a `.env` file in the backend directory with the following variables:
 # API Keys
 ANTHROPIC_API_KEY=your_anthropic_api_key    # Required for Claude model
 GROQ_API_KEY=your_groq_api_key              # Optional, for Groq model
+OPENAI_API_KEY=your_openai_api_key          # Optional, for OpenAI model
+OPENROUTER_API_KEY=your_openrouter_api_key  # Optional, for OpenRouter model
 
 # Database Configuration
 DB_PATH=./meetings.db                        # SQLite database path

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ FastAPI backend for meeting transcription and analysis
 ## Features
 - Audio file upload and storage
 - Real-time Whisper-based transcription with streaming support
-- Meeting analysis with LLMs (supports Claude, Groq, and Ollama)
+- Meeting analysis with LLMs (supports Claude, Groq, Ollama, OpenAI, and OpenRouter)
 - REST API endpoints
 
 ## Requirements
@@ -230,7 +230,7 @@ The backend runs two services:
 - If services fail to start, the script will automatically clean up processes
 - Check logs for detailed error messages
 - Ensure all ports (5167 for backend, 8178 for Whisper) are available
-- Verify API keys if using Claude or Groq
+ - Verify API keys if using Claude, Groq, OpenAI, or OpenRouter
 - For Ollama, ensure the Ollama service is running and models are pulled
 - If build fails:
   - Ensure all dependencies (CMake, C++ compiler) are installed

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -83,6 +83,7 @@ class DatabaseManager:
                     whisperModel TEXT NOT NULL,
                     groqApiKey TEXT,
                     openaiApiKey TEXT,
+                    openrouterApiKey TEXT,
                     anthropicApiKey TEXT,
                     ollamaApiKey TEXT
                 )
@@ -375,7 +376,7 @@ class DatabaseManager:
 
     async def save_api_key(self, api_key: str, provider: str):
         """Save the API key"""
-        provider_list = ["openai", "claude", "groq", "ollama"]
+        provider_list = ["openai", "claude", "groq", "ollama", "openrouter"]
         if provider not in provider_list:
             raise ValueError(f"Invalid provider: {provider}")
         if provider == "openai":
@@ -386,13 +387,15 @@ class DatabaseManager:
             api_key_name = "groqApiKey"
         elif provider == "ollama":
             api_key_name = "ollamaApiKey"
+        elif provider == "openrouter":
+            api_key_name = "openrouterApiKey"
         async with self._get_connection() as conn:
             await conn.execute(f"UPDATE settings SET {api_key_name} = ? WHERE id = '1'", (api_key,))
             await conn.commit()
 
     async def get_api_key(self, provider: str):
         """Get the API key"""
-        provider_list = ["openai", "claude", "groq", "ollama"]
+        provider_list = ["openai", "claude", "groq", "ollama", "openrouter"]
         if provider not in provider_list:
             raise ValueError(f"Invalid provider: {provider}")
         if provider == "openai":
@@ -403,6 +406,8 @@ class DatabaseManager:
             api_key_name = "groqApiKey"
         elif provider == "ollama":
             api_key_name = "ollamaApiKey"
+        elif provider == "openrouter":
+            api_key_name = "openrouterApiKey"
         async with self._get_connection() as conn:
             cursor = await conn.execute(f"SELECT {api_key_name} FROM settings WHERE id = '1'")
             row = await cursor.fetchone()
@@ -410,7 +415,7 @@ class DatabaseManager:
         
     async def delete_api_key(self, provider: str):
         """Delete the API key"""
-        provider_list = ["openai", "claude", "groq", "ollama"]
+        provider_list = ["openai", "claude", "groq", "ollama", "openrouter"]
         if provider not in provider_list:
             raise ValueError(f"Invalid provider: {provider}")
         if provider == "openai":
@@ -421,6 +426,8 @@ class DatabaseManager:
             api_key_name = "groqApiKey"
         elif provider == "ollama":
             api_key_name = "ollamaApiKey"
+        elif provider == "openrouter":
+            api_key_name = "openrouterApiKey"
         async with self._get_connection() as conn:
             await conn.execute(f"UPDATE settings SET {api_key_name} = NULL WHERE id = '1'")
             await conn.commit()

--- a/backend/app/transcript_processor.py
+++ b/backend/app/transcript_processor.py
@@ -102,6 +102,11 @@ class TranscriptProcessor:
                 if not api_key: raise ValueError("OPENAI_API_KEY environment variable not set")
                 llm = OpenAIModel(model_name, api_key=api_key)
                 logger.info(f"Using OpenAI model: {model_name}")
+            elif model == "openrouter":
+                api_key = await db.get_api_key("openrouter")
+                if not api_key: raise ValueError("OPENROUTER_API_KEY environment variable not set")
+                llm = OpenAIModel(model_name, api_key=api_key, base_url="https://openrouter.ai/api/v1")
+                logger.info(f"Using OpenRouter model: {model_name}")
             # --- END OPENAI SUPPORT ---
             else:
                 logger.error(f"Unsupported model provider requested: {model}")

--- a/backend/set_env.sh
+++ b/backend/set_env.sh
@@ -20,7 +20,7 @@ needs_update() {
 }
 
 # Update API keys in .env file
-for key in ANTHROPIC_API_KEY GROQ_API_KEY OPENAI_API_KEY; do
+for key in ANTHROPIC_API_KEY GROQ_API_KEY OPENAI_API_KEY OPENROUTER_API_KEY; do
     # Get current value from environment
     current_value="${!key}"
     
@@ -38,5 +38,5 @@ done
 
 # Print final environment variables
 echo "Final API Keys:"
-grep -E "^(ANTHROPIC|GROQ|OPENAI)_API_KEY=" .env
+grep -E "^(ANTHROPIC|GROQ|OPENAI|OPENROUTER)_API_KEY=" .env
 echo "Environment setup complete!"

--- a/backend/temp.env
+++ b/backend/temp.env
@@ -1,3 +1,4 @@
 ANTHROPIC_API_KEY=api_key_here
 GROQ_API_KEY=gapi_key_here
 OPENAI_API_KEY=api_key_here
+OPENROUTER_API_KEY=api_key_here


### PR DESCRIPTION
## Summary
- enable OpenRouter provider alongside existing models
- store OpenRouter API key
- document new environment variables and providers
- update environment setup script and template

## Testing
- `python -m py_compile backend/app/transcript_processor.py backend/app/db.py`

------
https://chatgpt.com/codex/tasks/task_e_68494a6bac84832993adbe078cbbda39