### PR TITLE
Update Windows model download fallback

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -108,6 +108,8 @@ Run the build script which will:
 - Build Whisper.cpp with custom server modifications
 - Set up the server package with required files
 - Download the selected Whisper model
+- The download script first tries **Start-BitsTransfer** and falls back to
+  **curl** or **Invoke-WebRequest** if BITS isn't available
 
 ```cmd
 ./build_whisper.cmd

--- a/backend/download-ggml-model.cmd
+++ b/backend/download-ggml-model.cmd
@@ -57,12 +57,24 @@ if %ERRORLEVEL% equ 0 (
     set "src=https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
 )
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Start-BitsTransfer -Source %src%/ggml-%model%.bin -Destination ggml-%model%.bin"
+set "url=%src%/ggml-%model%.bin"
+
+echo Attempting download using BITS...
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "try { Start-BitsTransfer -Source '%url%' -Destination 'ggml-%model%.bin' -ErrorAction Stop } catch { exit 1 }"
+
+if %ERRORLEVEL% neq 0 (
+  echo BITS transfer failed. Trying alternate method...
+  if exist "%SystemRoot%\System32\curl.exe" (
+    "%SystemRoot%\System32\curl.exe" -L -o "ggml-%model%.bin" "%url%"
+  ) else (
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri '%url%' -OutFile 'ggml-%model%.bin'"
+  )
+)
 
 if %ERRORLEVEL% neq 0 (
   echo Failed to download ggml model %model%
   echo Please try again later or download the original Whisper model files and convert them yourself.
-  goto :eof
+  exit /b 1
 )
 
 echo Done! Model %model% saved in %CD%\ggml-%model%.bin


### PR DESCRIPTION
## Summary
- improve `download-ggml-model.cmd` to fall back to curl or Invoke-WebRequest when BITS fails
- document the fallback behaviour in the backend build instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684952d5029c832988418c96c1b27217