### PR TITLE
Add Docker support for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,14 @@ cd meeting-minutes/backend
 git clone https://github.com/Zackriya-Solutions/meeting-minutes.git
 cd meeting-minutes
 
-# Run the Docker build script (interactive setup)
-.\docker-build.bat
+# Build and run the backend using Docker
+./build-docker.sh
 ```
+This script builds the Docker image defined in `backend/Dockerfile` and runs it
+while exposing ports `5167` and `8178`.
+
+Once running, the FastAPI backend is available at `http://localhost:5167` and
+the Whisper server at `http://localhost:8178`.
 
 ### Docker Configuration Options
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim as base
+
+# install build tools for whisper.cpp
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git curl ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# copy backend sources
+COPY backend/ ./backend/
+WORKDIR /app/backend
+
+# fetch whisper.cpp submodule and build whisper server
+RUN git submodule update --init --recursive \
+    && cd whisper.cpp \
+    && cp -r ../whisper-custom/server/* examples/server/ \
+    && mkdir build && cd build \
+    && cmake .. -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" \
+    && make -j$(nproc) \
+    && mkdir -p ../whisper-server-package \
+    && cp build/bin/whisper-server ../whisper-server-package/
+
+# download a default model (small) into package directory
+RUN mkdir -p whisper-server-package/models \
+    && bash ./download-ggml-model.sh small whisper-server-package/models
+
+# install python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 5167 8178
+CMD ["/entrypoint.sh"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -236,3 +236,14 @@ The backend runs two services:
   - Ensure all dependencies (CMake, C++ compiler) are installed
   - Check if git submodules are properly initialized
   - Verify you have write permissions in the directory
+
+## Docker
+
+The backend can also run inside a Docker container. Use the provided script from
+the repository root to build and start the container:
+
+```bash
+./build-docker.sh
+```
+
+This exposes ports `5167` (FastAPI) and `8178` (Whisper server).

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+WHISPER_DIR="whisper-server-package"
+WHISPER_MODEL="models/ggml-small.bin"
+
+# start whisper server
+./$WHISPER_DIR/whisper-server --model $WHISPER_DIR/$WHISPER_MODEL --host 0.0.0.0 --port 8178 --diarize --print-progress &
+WHISPER_PID=$!
+
+# start fastapi backend
+PORT=${PORT:-5167}
+uvicorn app.main:app --host 0.0.0.0 --port $PORT &
+BACKEND_PID=$!
+
+# wait for either process to exit
+wait -n $WHISPER_PID $BACKEND_PID
+
+

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+IMAGE_NAME="meetily-backend"
+
+docker build -t $IMAGE_NAME -f backend/Dockerfile .
+
+echo "Image built: $IMAGE_NAME"
+
+docker run --rm -p 5167:5167 -p 8178:8178 $IMAGE_NAME
+


### PR DESCRIPTION
## Summary
- introduce Dockerfile and entrypoint for backend
- provide helper script `build-docker.sh`
- document Docker usage in README files

## Testing
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684958740a048329a30833d13fc56248